### PR TITLE
[makerom/ctrtool] Made SystemMode(Ext) more meaningful.

### DIFF
--- a/ctrtool/exheader.c
+++ b/ctrtool/exheader.c
@@ -583,6 +583,41 @@ const char* exheader_getvalidstring(int valid)
 		return "(FAIL)";
 }
 
+const char* exheader_getsystemmodestring(u8 systemmode)
+{
+	switch (systemmode)
+	{
+	case (sysmode_64MB) :
+		return "64MB";
+	case (sysmode_96MB) :
+		return "96MB";
+	case (sysmode_80MB) :
+		return "80MB";
+	case (sysmode_72MB) :
+		return "72MB";
+	case (sysmode_32MB) :
+		return "32MB";
+	default:
+		return "Unknown";
+	}
+}
+
+const char* exheader_getsystemmodeextstring(u8 systemmodeext, u8 systemmode)
+{
+	switch (systemmodeext)
+	{
+	case (sysmode_ext_LEGACY) :
+		return exheader_getsystemmodestring(systemmode);
+	case (sysmode_ext_124MB) :
+		return "124MB";
+	case (sysmode_ext_178MB) :
+		return "178MB";
+	default:
+		return "124MB";
+	}
+}
+
+
 void exheader_print(exheader_context* ctx)
 {
 	u32 i;
@@ -635,8 +670,8 @@ void exheader_print(exheader_context* ctx)
 
 	fprintf(stdout, "Program id:             %016"PRIx64" %s\n", getle64(ctx->header.arm11systemlocalcaps.programid), exheader_getvalidstring(ctx->validprogramid));
 	fprintf(stdout, "Core version:           0x%X\n", getle32(ctx->header.arm11systemlocalcaps.coreversion));
-	fprintf(stdout, "System mode:            %d %s\n", ctx->system_local_caps.old3ds_systemmode, exheader_getvalidstring(ctx->validold3dssystemmode));
-	fprintf(stdout, "System mode (New3DS):   %d %s\n", ctx->system_local_caps.new3ds_systemmode, exheader_getvalidstring(ctx->validnew3dssystemmode));
+	fprintf(stdout, "System mode:            %s %s\n", exheader_getsystemmodestring(ctx->system_local_caps.old3ds_systemmode), exheader_getvalidstring(ctx->validold3dssystemmode));
+	fprintf(stdout, "System mode (New3DS):   %s %s\n", exheader_getsystemmodeextstring(ctx->system_local_caps.new3ds_systemmode, ctx->system_local_caps.old3ds_systemmode), exheader_getvalidstring(ctx->validnew3dssystemmode));
 	fprintf(stdout, "CPU Speed (New3DS):     %s %s\n", ctx->system_local_caps.new3ds_cpu_speed? "804MHz" : "268MHz", exheader_getvalidstring(ctx->validnew3dscpuspeed));
 	fprintf(stdout, "Enable L2 Cache:        %s %s\n", ctx->system_local_caps.enable_l2_cache ? "YES" : "NO", exheader_getvalidstring(ctx->validnew3dscpuspeed));
 	fprintf(stdout, "Ideal processor:        %d %s\n", ctx->system_local_caps.ideal_processor, exheader_getvalidstring(ctx->valididealprocessor));

--- a/ctrtool/exheader.h
+++ b/ctrtool/exheader.h
@@ -6,6 +6,23 @@
 #include "ctr.h"
 #include "settings.h"
 
+typedef enum
+{
+	sysmode_64MB,
+	sysmode_UNK,
+	sysmode_96MB,
+	sysmode_80MB,
+	sysmode_72MB,
+	sysmode_32MB,
+} exheader_systemmode;
+
+typedef enum
+{
+	sysmode_ext_LEGACY,
+	sysmode_ext_124MB,
+	sysmode_ext_178MB,
+} exheader_systemmodeext;
+
 typedef struct
 {
 	u8 reserved[5];

--- a/makerom/exheader.c
+++ b/makerom/exheader.c
@@ -334,14 +334,21 @@ int SetARM11SystemLocalInfoFlags(exhdr_ARM11SystemLocalCapabilities *arm11, rsf_
 		arm11->flag[0] |= cpuspeed_268MHz << 1;
 
 	/* Flag[1] (SystemModeExt) */
-	u8 systemModeExt = 0;
 	if (rsf->AccessControlInfo.SystemModeExt) {
-		systemModeExt = strtol(rsf->AccessControlInfo.SystemModeExt, NULL, 0);
-		if (systemModeExt > 15) {
-			fprintf(stderr, "[EXHEADER ERROR] Unexpected SystemModeExt: 0x%x. Expected range: 0x0 - 0xf\n", systemModeExt);
+		if (strcasecmp(rsf->AccessControlInfo.SystemModeExt, "Legacy") == 0)
+			arm11->flag[1] = sysmode_ext_LEGACY;
+		else if (strcasecmp(rsf->AccessControlInfo.SystemModeExt, "124MB") == 0)
+			arm11->flag[1] = sysmode_ext_124MB;
+		else if (strcasecmp(rsf->AccessControlInfo.SystemModeExt, "178MB") == 0)
+			arm11->flag[1] = sysmode_ext_178MB;
+		
+		else {
+			fprintf(stderr, "[EXHEADER ERROR] Unexpected SystemModeExt: %s\n", rsf->AccessControlInfo.SystemModeExt);
 			return EXHDR_BAD_RSF_OPT;
 		}
-		arm11->flag[1] = systemModeExt & 0xf;
+	} 
+	else {
+		arm11->flag[1] = sysmode_ext_LEGACY;
 	}
 
 	/* Flag[2] */
@@ -364,11 +371,26 @@ int SetARM11SystemLocalInfoFlags(exhdr_ARM11SystemLocalCapabilities *arm11, rsf_
 		}
 	}
 	if(rsf->AccessControlInfo.SystemMode){
-		systemMode = strtol(rsf->AccessControlInfo.SystemMode,NULL,0);
-		if(systemMode > 15){
-			fprintf(stderr,"[EXHEADER ERROR] Unexpected SystemMode: 0x%x. Expected range: 0x0 - 0xf\n",systemMode);
+		if (strcasecmp(rsf->AccessControlInfo.SystemMode, "64MB") == 0 || strcasecmp(rsf->AccessControlInfo.SystemMode, "prod") == 0)
+			systemMode = sysmode_64MB;
+		//else if (strcasecmp(rsf->AccessControlInfo.SystemMode, "UNK") == 0 || strcasecmp(rsf->AccessControlInfo.SystemMode, "null") == 0)
+		//	systemMode = sysmode_UNK;
+		else if (strcasecmp(rsf->AccessControlInfo.SystemMode, "96MB") == 0 || strcasecmp(rsf->AccessControlInfo.SystemMode, "dev1") == 0)
+			systemMode = sysmode_96MB;
+		else if (strcasecmp(rsf->AccessControlInfo.SystemMode, "80MB") == 0 || strcasecmp(rsf->AccessControlInfo.SystemMode, "dev2") == 0)
+			systemMode = sysmode_80MB;
+		else if (strcasecmp(rsf->AccessControlInfo.SystemMode, "72MB") == 0 || strcasecmp(rsf->AccessControlInfo.SystemMode, "dev3") == 0)
+			systemMode = sysmode_72MB;
+		else if (strcasecmp(rsf->AccessControlInfo.SystemMode, "32MB") == 0 || strcasecmp(rsf->AccessControlInfo.SystemMode, "dev4") == 0)
+			systemMode = sysmode_32MB;
+
+		else {
+			fprintf(stderr, "[EXHEADER ERROR] Unexpected SystemMode: %s\n", rsf->AccessControlInfo.SystemMode);
 			return EXHDR_BAD_RSF_OPT;
 		}
+	}
+	else {
+		systemMode = sysmode_64MB;
 	}
 	arm11->flag[2] = (u8)(systemMode << 4 | affinityMask << 2 | idealProcessor);
 

--- a/makerom/exheader.h
+++ b/makerom/exheader.h
@@ -8,6 +8,23 @@ typedef enum
 
 typedef enum
 {
+	sysmode_64MB, // prod
+	sysmode_UNK, // null
+	sysmode_96MB, // dev1
+	sysmode_80MB, // dev2
+	sysmode_72MB, // dev3
+	sysmode_32MB, // dev4
+} system_mode;
+
+typedef enum
+{
+	sysmode_ext_LEGACY,
+	sysmode_ext_124MB, // snake Prod
+	sysmode_ext_178MB, // snake Dev1
+} system_mode_ext;
+
+typedef enum
+{
 	memtype_APPLICATION = 1,
     memtype_SYSTEM = 2,
     memtype_BASE = 3


### PR DESCRIPTION
SystemMode(Ext) now accepts application memory sizes, instead of values related to APPMEMTYPE.


New usage:
SystemMode: 64MB/96MB/80MB/72MB/32MB
SystemModeExt: Legacy,124MB,178MB.

"Legacy" means that for N3DS, the SystemMode value will be used.