### PR TITLE
[makerom/ctrtool] fixes + enhancements

### DIFF
--- a/ctrtool/ncch.c
+++ b/ctrtool/ncch.c
@@ -575,7 +575,7 @@ void ncch_print(ncch_context* ctx)
 		memdump(stdout, "Signature (FAIL):       ", header->signature, 0x100);
 	fprintf(stdout, "Content size:           0x%08x\n", getle32(header->contentsize)*mediaunitsize);
 	fprintf(stdout, "Partition id:           %016"PRIx64"\n", getle64(header->partitionid));
-	fprintf(stdout, "Maker code:             %04x\n", getle16(header->makercode));
+	fprintf(stdout, "Maker code:             %.2s\n", header->makercode);
 	fprintf(stdout, "Version:                %04x\n", getle16(header->version));
 	fprintf(stdout, "Title seed check:       %08x\n", getle32(header->seedcheck));
 	fprintf(stdout, "Program id:             %016"PRIx64"\n", getle64(header->programid));

--- a/makerom/elf_hdr.h
+++ b/makerom/elf_hdr.h
@@ -161,6 +161,7 @@ typedef struct
 #define PT_LOPROC	0x70000000	/* Start of processor-specific */
 #define PT_HIPROC	0x7fffffff	/* End of processor-specific */
 
+#define PF_CTRSDK	0x80000000
 #define	PF_R		0x4		/* p_flags */
 #define	PF_W		0x2
 #define	PF_X		0x1

--- a/makerom/exheader.c
+++ b/makerom/exheader.c
@@ -4,6 +4,7 @@
 #include "accessdesc.h"
 #include "titleid.h"
 
+const char *DEFAULT_EXHEADER_NAME = "CtrApp";
 
 /* Prototypes */
 void free_ExHeaderSettings(exheader_settings *exhdrset);
@@ -189,17 +190,10 @@ finish:
 int get_ExHeaderCodeSetInfo(exhdr_CodeSetInfo *CodeSetInfo, rsf_settings *rsf)
 {
 	/* Name */
-	if(rsf->BasicInfo.Title){
-		//if(strlen(rsf->BasicInfo.Title) > 8){
-		//	fprintf(stderr,"[EXHEADER ERROR] Parameter Too Long \"BasicInfo/Title\"\n");
-		//	return EXHDR_BAD_RSF_OPT;
-		//}
-		strncpy((char*)CodeSetInfo->name,rsf->BasicInfo.Title,8);
-	}
-	else{
-		ErrorParamNotFound("BasicInfo/Title");
-		return EXHDR_BAD_RSF_OPT;
-	}
+	if (rsf->BasicInfo.Title)
+		strncpy((char*)CodeSetInfo->name, rsf->BasicInfo.Title, 8);
+	else
+		strncpy((char*)CodeSetInfo->name, DEFAULT_EXHEADER_NAME, 8);
 	
 	/* Stack Size */
 	if(rsf->SystemControlInfo.StackSize)

--- a/makerom/ncch.c
+++ b/makerom/ncch.c
@@ -12,6 +12,8 @@
 #include "ncch_logo.h" // Contains Logos
 
 const u32 NCCH_BLOCK_SIZE = 0x200;
+const char *DEFAULT_PRODUCT_CODE = "CTR-P-CTAP";
+const char *DEFAULT_MAKER_CODE = "00";
 
 // Private Prototypes
 int SignCFA(ncch_hdr *hdr, keys_struct *keys);
@@ -591,18 +593,20 @@ int SetCommonHeaderBasicData(ncch_settings *set, ncch_hdr *hdr)
 			fprintf(stderr,"[NCCH ERROR] Invalid Product Code\n");
 			return NCCH_BAD_RSF_SET;
 		}
-		memcpy(hdr->productCode,set->rsfSet->BasicInfo.ProductCode,strlen((char*)set->rsfSet->BasicInfo.ProductCode));
+		strncpy((char*)hdr->productCode,set->rsfSet->BasicInfo.ProductCode, 16);
 	}
-	else memcpy(hdr->productCode,"CTR-P-CTAP",10);
+	else
+		strncpy((char*)hdr->productCode, DEFAULT_PRODUCT_CODE, 16);
 
 	if(set->rsfSet->BasicInfo.CompanyCode){
 		if(strlen((char*)set->rsfSet->BasicInfo.CompanyCode) != 2){
 			fprintf(stderr,"[NCCH ERROR] CompanyCode length must be 2\n");
 			return NCCH_BAD_RSF_SET;
 		}
-		memcpy(hdr->makerCode,set->rsfSet->BasicInfo.CompanyCode,2);
+		strncpy((char*)hdr->makerCode, set->rsfSet->BasicInfo.CompanyCode, 2);
 	}
-	else memcpy(hdr->makerCode,"00",2);
+	else
+		strncpy((char*)hdr->makerCode, DEFAULT_MAKER_CODE, 2);
 
 	// Setting Encryption Settings
 	if(!set->options.Encrypt)

--- a/makerom/rsf_settings.c
+++ b/makerom/rsf_settings.c
@@ -5,8 +5,6 @@ void GET_AccessControlInfo(ctr_yaml_context *ctx, rsf_settings *rsf);
 void GET_SystemControlInfo(ctr_yaml_context *ctx, rsf_settings *rsf);
 void GET_BasicInfo(ctr_yaml_context *ctx, rsf_settings *rsf);
 void GET_RomFs(ctr_yaml_context *ctx, rsf_settings *rsf);
-void GET_ExeFs(ctr_yaml_context *ctx, rsf_settings *rsf);
-void GET_PlainRegion(ctr_yaml_context *ctx, rsf_settings *rsf);
 void GET_TitleInfo(ctr_yaml_context *ctx, rsf_settings *rsf);
 void GET_CardInfo(ctr_yaml_context *ctx, rsf_settings *rsf);
 void GET_CommonHeaderKey(ctr_yaml_context *ctx, rsf_settings *rsf);
@@ -23,8 +21,6 @@ void EvaluateRSF(rsf_settings *rsf, ctr_yaml_context *ctx)
 	else if(cmpYamlValue("SystemControlInfo",ctx)) {FinishEvent(ctx); GET_SystemControlInfo(ctx,rsf); goto GET_NextGroup;}
 	else if(cmpYamlValue("BasicInfo",ctx)) {FinishEvent(ctx); GET_BasicInfo(ctx,rsf); goto GET_NextGroup;}
 	else if(cmpYamlValue("RomFs",ctx)) {FinishEvent(ctx); GET_RomFs(ctx,rsf); goto GET_NextGroup;}
-	else if(cmpYamlValue("ExeFs",ctx)) {FinishEvent(ctx); GET_ExeFs(ctx,rsf); goto GET_NextGroup;}
-	else if(cmpYamlValue("PlainRegion",ctx)) {FinishEvent(ctx); GET_PlainRegion(ctx,rsf); goto GET_NextGroup;}
 	else if(cmpYamlValue("TitleInfo",ctx)) {FinishEvent(ctx); GET_TitleInfo(ctx,rsf); goto GET_NextGroup;}
 	else if(cmpYamlValue("CardInfo",ctx)) {FinishEvent(ctx); GET_CardInfo(ctx,rsf); goto GET_NextGroup;}
 	else if(cmpYamlValue("CommonHeaderKey",ctx)) {FinishEvent(ctx); GET_CommonHeaderKey(ctx,rsf); goto GET_NextGroup;}
@@ -240,39 +236,6 @@ void GET_RomFs(ctr_yaml_context *ctx, rsf_settings *rsf)
 	FinishEvent(ctx);
 }
 
-void GET_ExeFs(ctr_yaml_context *ctx, rsf_settings *rsf)
-{
-	/* Checking That Group is in a map */
-	if(!CheckMappingEvent(ctx)) return;
-	u32 InitLevel = ctx->Level;
-	/* Checking each child */
-	GetEvent(ctx);
-	while(ctx->Level == InitLevel){
-		if(ctx->error || ctx->done) return;
-		// Handle childs
-		
-		if(cmpYamlValue("Text",ctx)) rsf->ExeFs.TextNum = SetYAMLSequence(&rsf->ExeFs.Text,"Text",ctx);
-		else if(cmpYamlValue("ReadOnly",ctx)) rsf->ExeFs.ReadOnlyNum = SetYAMLSequence(&rsf->ExeFs.ReadOnly,"ReadOnly",ctx);
-		else if(cmpYamlValue("ReadWrite",ctx)) rsf->ExeFs.ReadWriteNum = SetYAMLSequence(&rsf->ExeFs.ReadWrite,"ReadWrite",ctx);
-		
-		else{
-			fprintf(stderr,"[RSF ERROR] Unrecognised key '%s'\n",GetYamlString(ctx));
-			ctx->error = YAML_UNKNOWN_KEY;
-			FinishEvent(ctx);
-			return;
-		}
-		// Finish event start next
-		FinishEvent(ctx);
-		GetEvent(ctx);
-	}
-	FinishEvent(ctx);
-}
-
-void GET_PlainRegion(ctr_yaml_context *ctx, rsf_settings *rsf)
-{
-	rsf->PlainRegionNum = SetYAMLSequence(&rsf->PlainRegion,"PlainRegion",ctx);
-}
-
 void GET_TitleInfo(ctr_yaml_context *ctx, rsf_settings *rsf)
 {
 	/* Checking That Group is in a map */
@@ -486,28 +449,6 @@ void free_RsfSettings(rsf_settings *set)
 		free(set->RomFs.File[i]);
 	}
 	free(set->RomFs.File);
-	
-	//ExeFs
-	for(u32 i = 0; i < set->ExeFs.TextNum; i++){
-		free(set->ExeFs.Text[i]);
-	}
-	free(set->ExeFs.Text);
-	
-	for(u32 i = 0; i < set->ExeFs.ReadOnlyNum; i++){
-		free(set->ExeFs.ReadOnly[i]);
-	}
-	free(set->ExeFs.ReadOnly);
-	
-	for(u32 i = 0; i < set->ExeFs.ReadWriteNum; i++){
-		free(set->ExeFs.ReadWrite[i]);
-	}
-	free(set->ExeFs.ReadWrite);
-	
-	//PlainRegion
-	for(u32 i = 0; i < set->PlainRegionNum; i++){
-		free(set->PlainRegion[i]);
-	}
-	free(set->PlainRegion);
 	
 	//TitleInfo
 	free(set->TitleInfo.Platform);

--- a/makerom/titleid.c
+++ b/makerom/titleid.c
@@ -2,6 +2,8 @@
 #include "ncch_read.h"
 #include "titleid.h"
 
+const u32 DEFAULT_UNIQUE_ID = 0xff3ff;
+
 void SetPIDType(u16 *type);
 int SetPIDCategoryFromName(u16 *cat, char *CategoryStr);
 int SetPIDCategoryFromFlags(u16 *cat, char **CategoryFlags, u32 FlagNum);
@@ -52,10 +54,8 @@ int GetProgramID(u64 *dest, rsf_settings *rsf, bool IsForExheader)
 	// Getting UniqueId
 	if(rsf->TitleInfo.UniqueId) 
 		GetUniqueID(&uniqueId,rsf);
-	else{
-		fprintf(stderr,"[ID ERROR] ParameterNotFound: \"TitleInfo/UniqueId\"\n");
-		return PID_BAD_RSF_SET;
-	}
+	else
+		uniqueId = DEFAULT_UNIQUE_ID;
 
 	// Getting Variation
 	if(SetTitleVariation(&variation,category,rsf) == PID_INVALID_VARIATION)

--- a/makerom/user_settings.h
+++ b/makerom/user_settings.h
@@ -170,18 +170,6 @@ typedef struct
 	} RomFs;
 	
 	struct{
-		u32 TextNum;
-		char **Text;
-		u32 ReadOnlyNum;
-		char **ReadOnly;
-		u32 ReadWriteNum;
-		char **ReadWrite;
-	} ExeFs;
-	
-	u32 PlainRegionNum;
-	char **PlainRegion;
-	
-	struct{
 		// Strings
 		char *Platform;
 		char *Category;


### PR DESCRIPTION
Important changes:
Enhanced: makerom can auto-find code segments from within an ELF.
Removed: RSF keys "ExeFs", "PlainRegion" and associated children are not needed, and hence are no longer recognized as valid RSF keys.
Fixed: ctrtool now displays NCCH MakerCode as a string.

Also, since I've altered the RSF format over the time of writing v0.14, here are some sample RSF files that will work with 0.14 that have all relevant keys included:
Basic RSF: https://gist.github.com/jakcron/605ef8c659896348cdb9
RSF for those who like build scripts: https://gist.github.com/jakcron/586ca4476dd8a0efb010