### PR TITLE
[makerom] Fixed CpuSpeed typo.

### DIFF
--- a/makerom/exheader.c
+++ b/makerom/exheader.c
@@ -315,7 +315,7 @@ int SetARM11SystemLocalInfoFlags(exhdr_ARM11SystemLocalCapabilities *arm11, rsf_
 	arm11->flag[0] |= rsf->AccessControlInfo.EnableL2Cache;
 
 	if (rsf->AccessControlInfo.CpuSpeed) {
-		if(strcasecmp(rsf->AccessControlInfo.CpuSpeed, "256mhz") == 0)
+		if(strcasecmp(rsf->AccessControlInfo.CpuSpeed, "268mhz") == 0)
 			arm11->flag[0] |= cpuspeed_268MHz << 1;
 		else if(strcasecmp(rsf->AccessControlInfo.CpuSpeed, "804mhz") == 0)
 			arm11->flag[0] |= cpuspeed_804MHz << 1;


### PR DESCRIPTION
Fixed: "AccessControlInfo/CpuSpeed" typo.

Old firmware friendly + typo fixed RSFs
Basic RSF: https://gist.github.com/jakcron/9f9f02ffd94d98a72632
Build System RSF: https://gist.github.com/jakcron/c3801fc54d0e4347e385