### PR TITLE
Fix build with gcc on some platforms.

### DIFF
--- a/ctrtool/Makefile
+++ b/ctrtool/Makefile
@@ -5,7 +5,7 @@ OBJS = $(foreach dir,$(SRC_DIR),$(subst .c,.o,$(wildcard $(dir)/*.c))) $(foreach
 # Compiler Settings
 OUTPUT = ctrtool
 CXXFLAGS = -I.
-CFLAGS = -O2 -flto -Wall -Wno-unused-variable  -Wno-unused-result -I.
+CFLAGS = -O2 -flto -Wall -Wno-unused-variable  -Wno-unused-result -I. -std=c99
 CC = gcc
 CXX = g++
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
Build would otherwise error as follows:

    ctr.c: In function 'ctr_add_counter':
    ctr.c:25:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode