### PR TITLE
Add system calls for 11.3 and 11.4

### DIFF
--- a/ctrtool/Makefile
+++ b/ctrtool/Makefile
@@ -5,7 +5,7 @@ OBJS = $(foreach dir,$(SRC_DIR),$(subst .c,.o,$(wildcard $(dir)/*.c))) $(foreach
 # Compiler Settings
 OUTPUT = ctrtool
 CXXFLAGS = -I.
-CFLAGS = -O2 -Wall -Wno-unused-variable  -Wno-unused-result -I. -std=c99
+CFLAGS = -O2 -Wall -Wno-unused-variable  -Wno-unused-result -I. -std=c11
 CC = gcc
 CXX = g++
 SYS := $(shell gcc -dumpmachine)

--- a/ctrtool/cwav.c
+++ b/ctrtool/cwav.c
@@ -814,6 +814,8 @@ int cwav_pcm_setup(cwav_pcmstate* state, cwav_context* ctx, int isloop)
 			startoffset = getle32(ctx->infoheader.loopstart);
 		else if (ctx->infoheader.encoding == CWAV_ENCODING_PCM16)
 			startoffset = getle32(ctx->infoheader.loopstart) * 2;
+		else
+			startoffset = 0;
 	}
 	else
 	{

--- a/ctrtool/syscalls.c
+++ b/ctrtool/syscalls.c
@@ -95,8 +95,8 @@ static const char *const syscall_list[NUM_SYSCALLS] =
 	"StopDma",                           // 56
 	"GetDmaState",                       // 57
 	"RestartDma",                        // 58
-	NULL,                                // 59
-	NULL,                                // 5A
+	"SetGpuProt",                        // 59
+	"SetWifiEnabled",                    // 5A
 	NULL,                                // 5B
 	NULL,                                // 5C
 	NULL,                                // 5D
@@ -139,7 +139,8 @@ static const char *const syscall_list[NUM_SYSCALLS] =
 
 void syscall_get_name(char *output, size_t size, unsigned int call_num)
 {
-	typedef char StaticAssert[sizeof(syscall_list) / sizeof(syscall_list[0]) == NUM_SYSCALLS ? 1 : -1];
+	_Static_assert(sizeof(syscall_list) / sizeof(syscall_list[0]) == NUM_SYSCALLS,
+		"syscall table length mismatch");
 
 	if (size == 0)
 	{


### PR DESCRIPTION
 * Add system calls for 11.3 and 11.4.
 * Switch from C99 to C11 to get _Static_assert.
 * Fix uninitialized variable warning in cwav.c.