### PR TITLE
makefile fix: make complains "Extraneous text after `else' directive"

### DIFF
--- a/ctrtool/Makefile
+++ b/ctrtool/Makefile
@@ -12,11 +12,11 @@ SYS := $(shell gcc -dumpmachine)
 ifneq (, $(findstring linux, $(SYS)))
     # Linux
     CFLAGS += -Wno-unused-but-set-variable
-else ifneq(, $(findstring cygwin, $(SYS)))
+else ifneq (, $(findstring cygwin, $(SYS)))
     # Cygwin
     CFLAGS += -Wno-unused-but-set-variable -DUSE_FILE32API
     LIBS += -liconv -static-libgcc -static-libstdc++
-else ifneq(, $(findstring darwin, $(SYS)))
+else ifneq (, $(findstring darwin, $(SYS)))
     # OS X
     LIBS += -liconv
 else

--- a/makerom/Makefile
+++ b/makerom/Makefile
@@ -10,11 +10,11 @@ SYS := $(shell gcc -dumpmachine)
 ifneq (, $(findstring linux, $(SYS)))
     # Linux
     CFLAGS += -Wno-unused-but-set-variable
-else ifneq(, $(findstring cygwin, $(SYS)))
+else ifneq (, $(findstring cygwin, $(SYS)))
     # Cygwin
     CFLAGS += -Wno-unused-but-set-variable
     LIBS += -liconv
-else ifneq(, $(findstring darwin, $(SYS)))
+else ifneq (, $(findstring darwin, $(SYS)))
     # OS X
     LIBS += -liconv
 else


### PR DESCRIPTION
make complains "Extraneous text after `else' directive" and cause incorrect platform judgement on os x

should I create an issue first?