### PR TITLE
[makerom] Add support for New3DS bit in Title ID

### DIFF
--- a/makerom/src/ncch.c
+++ b/makerom/src/ncch.c
@@ -234,6 +234,7 @@ int GetBasicOptions(ncch_settings *ncchset, user_settings *usrset)
 	ncchset->options.UseOnSD = ncchset->rsfSet->Option.UseOnSD;
 	ncchset->options.Encrypt = ncchset->rsfSet->Option.EnableCrypt;
 	ncchset->options.FreeProductCode = ncchset->rsfSet->Option.FreeProductCode;
+	ncchset->options.KtrProgramId = ncchset->rsfSet->Option.UseKtrProgramId;
 	ncchset->options.IsCfa = (usrset->ncch.ncchType == CFA);
 	ncchset->options.IsBuildingCodeSection = (usrset->ncch.elfPath != NULL);
 	ncchset->options.UseRomFS = ((ncchset->rsfSet->RomFs.RootPath && strlen(ncchset->rsfSet->RomFs.RootPath) > 0) || usrset->ncch.romfsPath);

--- a/makerom/src/ncch_build.h
+++ b/makerom/src/ncch_build.h
@@ -22,6 +22,7 @@ typedef struct
 		bool UseRomFS;
 		bool noCodePadding;
 		bool baremetal;
+		bool KtrProgramId;
 
 		bool useSecCrypto;
 		u8 keyXID;

--- a/makerom/src/rsf_settings.c
+++ b/makerom/src/rsf_settings.c
@@ -64,6 +64,7 @@ void GET_Option(ctr_yaml_context *ctx, rsf_settings *rsf)
 		else if(cmpYamlValue("EnableCompress",ctx)) SetBoolYAMLValue(&rsf->Option.EnableCompress,"EnableCompress",ctx);
 		else if(cmpYamlValue("FreeProductCode",ctx)) SetBoolYAMLValue(&rsf->Option.FreeProductCode,"FreeProductCode",ctx);
 		else if(cmpYamlValue("UseOnSD",ctx)) SetBoolYAMLValue(&rsf->Option.UseOnSD,"UseOnSD",ctx);
+		else if(cmpYamlValue("UseKtrProgramId",ctx)) SetBoolYAMLValue(&rsf->Option.UseKtrProgramId,"UseKtrProgramId",ctx);
 		else{
 			fprintf(stderr,"[RSF ERROR] Unrecognised key '%s'\n",GetYamlString(ctx));
 			ctx->error = YAML_UNKNOWN_KEY;

--- a/makerom/src/titleid.c
+++ b/makerom/src/titleid.c
@@ -75,6 +75,9 @@ int GetProgramID(u64 *dest, rsf_settings *rsf, bool IsForExheader)
 	programId |= (u64)uniqueId<<8;
 	programId |= (u64)category<<32;
 	programId |= (u64)type<<48;
+	
+	if (rsf->Option.UseKtrProgramId)
+		programId |= 0x20000000;
 
 	*dest = programId;
 

--- a/makerom/src/user_settings.c
+++ b/makerom/src/user_settings.c
@@ -100,6 +100,7 @@ void SetDefaults(user_settings *set)
 	set->ncch.noCodePadding = false;
 	set->ncch.baremetal = false;
 	set->ncch.pageSize = DEFAULT_STACK_SIZE;
+	set->ncch.ktrProgramId = false;
 
 	// RSF Settings
 	clrmem(&set->common.rsfSet, sizeof(rsf_settings));

--- a/makerom/src/user_settings.h
+++ b/makerom/src/user_settings.h
@@ -70,6 +70,7 @@ typedef struct
 		bool EnableCompress;
 		bool FreeProductCode;
 		bool UseOnSD;
+		bool UseKtrProgramId;
 	} Option;
 	
 	struct{
@@ -271,6 +272,7 @@ typedef struct
 		bool baremetal; // abuse K9/LGY K11's lack of memory management to support arbitrary VMA and RWX phdr
 		u32 pageSize; // Memory page size (256 for Kernel9, 4096 for anything else)
 		bool useSecCrypto;
+		bool ktrProgramId;
 		u8 keyXID;
 	} ncch; // Ncch0 Build
 	


### PR DESCRIPTION
Makerom is currently missing the functionality to add the New3DS-only bit to title IDs. This makes it impossible to use makerom for creating New3DS-only variations of certain system titles, e.g.:

mcu uses title ID `0004013000001F02`.
but the New3DS specific variation of it uses `0004013020001F02`.

I have added this functionality through the use of a new Option field `UseKtrProgramId` in the RSF. I'm open to renaming the field or using an alternative method to specify this option, though I thought adding it to the RSF would be the most fitting in this case.